### PR TITLE
#86 Change color to theme color in TabNavigator

### DIFF
--- a/navigation/TabNavigator.tsx
+++ b/navigation/TabNavigator.tsx
@@ -36,8 +36,8 @@ export default function TabNavigator() {
         lazy: false,
         tabBarStyle: styles.container,
         tabBarShowLabel: false,
-        tabBarActiveTintColor: "tomato",
-        tabBarInactiveTintColor: "gray",
+        tabBarActiveTintColor: Theme.colors.bazaarRed,
+        tabBarInactiveTintColor: Theme.colors.secondary,
       }}
     >
       <Tab.Screen


### PR DESCRIPTION
Now tabBarActiveTintColor has Theme.colors.bazaarRed and tabBarInactiveTintColor has Theme.colors.secondary as colors.
Before it was 'tomato' and 'gray'.

closed #86 