### PR TITLE
#88 Change name to Login and Main. Change title to 'Login'

### DIFF
--- a/navigation/RootNavigation.tsx
+++ b/navigation/RootNavigation.tsx
@@ -18,10 +18,10 @@ export default function RootNavigation() {
     <Stack.Navigator>
       {userToken == null ? (
         <Stack.Screen
-          name="SignIn"
+          name="LogIn"
           component={LoginScreen}
           options={{
-            title: "Sign in",
+            title: "Login",
             headerTransparent: true,
             headerTitleAlign: "center",
             headerStyle: {
@@ -33,7 +33,7 @@ export default function RootNavigation() {
         />
       ) : (
         <Stack.Screen
-          name="test"
+          name="Main"
           component={TabNavigator}
           options={{ headerShown: false }}
         />


### PR DESCRIPTION
In RootNavigation I change the first Stack-screens name from 'SignIn' to 'Login' and its title for the header from 'Sign In' to 'Login'.
And I change the second Stack.Screens name from 'test' to 'Main'.

closed #88 