### PR TITLE
#117 Fix product behind TabNav

### DIFF
--- a/screens/MyScreen.tsx
+++ b/screens/MyScreen.tsx
@@ -99,5 +99,6 @@ const styles = StyleSheet.create({
   flatListContent: {
     height: 100,
     paddingHorizontal: 15,
+    marginBottom: 80,
   },
 });


### PR DESCRIPTION
Add marginbuttom 80 on flatlistContent on MyScreen.

Now the last product on MyScreen isnt hidden behind TabNavigatorn.

Make issue to se if we can make only the last product have the marginBottom.

closed #117 